### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ Thanks
 
 Changelog
 -----------------------------
-* <a href="https://github.com/alistapart/ala-eecms/commit/b1e14906f06575f0e252053d2616a16e2a26db09">update pi.textile.php</a>
+* <a href="https://github.com/linssen/textile.ee_addon/commit/09be0df8178f3cfd2531f953d643516b45d6e47a">update pi.textile.php</a>
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ Thanks
 
 * Rick Ellis for [Textile EE 1.x version](http://expressionengine.com/downloads/details/textile/)
 * [F. Albrecht](http://www.ideenhafen.de/) for porting it to EE 2.x
+* 
+
+Changelog
+-----------------------------
+* <a href="https://github.com/alistapart/ala-eecms/commit/b1e14906f06575f0e252053d2616a16e2a26db09">update pi.textile.php</a>
+


### PR DESCRIPTION
Patch for deprecation notice after PHP 5.5.0 (notice: preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead)
